### PR TITLE
(refactor)insert documents to struct

### DIFF
--- a/server/internal/handlers/users/handler.go
+++ b/server/internal/handlers/users/handler.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"encoding/json"
+	"github.com/rusmDocs/rusmDocs/pkg/exceptionCodes"
 	"net/http"
 )
 
@@ -27,7 +28,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	err = user.createUser(userBody)
 	if err != nil {
 		switch err.Error() {
-		case "email conflict":
+		case exceptionCodes.MakeException(exceptionCodes.EntityExists, "user"):
 			w.WriteHeader(http.StatusConflict)
 			return
 		}
@@ -48,10 +49,10 @@ func LoginUser(w http.ResponseWriter, r *http.Request) {
 	err = user.checkUser(userBody)
 	if err != nil {
 		switch err.Error() {
-		case "user not found":
+		case exceptionCodes.MakeException(exceptionCodes.EntityNotFound, "user"):
 			w.WriteHeader(http.StatusNotFound)
 			return
-		case "incorrect password":
+		case exceptionCodes.MakeException(exceptionCodes.EntityInvalid, "user"):
 			w.WriteHeader(http.StatusUnauthorized)
 		}
 	}

--- a/server/internal/handlers/users/service.go
+++ b/server/internal/handlers/users/service.go
@@ -17,11 +17,7 @@ func (user *User) createUser(body RegisterBody) error {
 
 	coll := database.UseCollection("users")
 
-	result, err := coll.InsertOne(ctx, bson.D{
-		{"login", body.Login},
-		{"password", body.Password},
-		{"email", body.Email},
-	})
+	result, err := coll.InsertOne(ctx, body)
 
 	if err != nil {
 		return errors.New(

--- a/server/internal/handlers/users/service.go
+++ b/server/internal/handlers/users/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rusmDocs/rusmDocs/pkg/database"
+	"github.com/rusmDocs/rusmDocs/pkg/exceptionCodes"
 )
 
 func (user *User) createUser(body RegisterBody) error {
@@ -23,7 +24,9 @@ func (user *User) createUser(body RegisterBody) error {
 	})
 
 	if err != nil {
-		return errors.New("email conflict")
+		return errors.New(
+			exceptionCodes.MakeException(exceptionCodes.EntityExists, "user"),
+		)
 	}
 
 	err = coll.FindOne(ctx, bson.D{
@@ -46,7 +49,9 @@ func (user *User) checkUser(body LoginBody) error {
 	}
 
 	if user.Password != body.Password {
-		return errors.New("incorrect password")
+		return errors.New(
+			exceptionCodes.MakeException(exceptionCodes.EntityInvalid, "user"),
+		)
 	}
 
 	return nil

--- a/server/pkg/exceptionCodes/main.go
+++ b/server/pkg/exceptionCodes/main.go
@@ -1,0 +1,13 @@
+package exceptionCodes
+
+import "fmt"
+
+const (
+	EntityNotFound = "%s not found"
+	EntityExists   = "%s already exists"
+	EntityInvalid  = "%s is invalid"
+)
+
+func MakeException(code string, entity string) string {
+	return fmt.Sprintf(code, entity)
+}


### PR DESCRIPTION
WID
I changed a large syntax bson.D insertings to a little struct syntax

Premises
bson.D insert like
`
bson.D{
    {"email", body.email}
    // ...
}
` looks so terrible. It's can be easy to change via struct with bson tag

Changes
- userService insert bson.D in register was changed to structure