### PR TITLE
Changed bsonD documents to structs with bson tag

### DIFF
--- a/server/internal/handlers/users/service.go
+++ b/server/internal/handlers/users/service.go
@@ -17,11 +17,7 @@ func (user *User) createUser(body RegisterBody) error {
 
 	coll := database.UseCollection("users")
 
-	result, err := coll.InsertOne(ctx, bson.D{
-		{"login", body.Login},
-		{"password", body.Password},
-		{"email", body.Email},
-	})
+	result, err := coll.InsertOne(ctx, body)
 
 	if err != nil {
 		return errors.New(


### PR DESCRIPTION
# WID
I replace bson.D insert to inserting with struct. 

## Premise
bson.D looks large but structure insirting seems similarly clean and more readable.

## Changes
- userService insert new user  bson.D replaced to struct